### PR TITLE
Upgrade to work with new AST format

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-const AST = require('idyll-ast');
+const { convertV1ToV2, convertV2ToV1 } = require('idyll-ast').converters;
+const AST = require('idyll-ast/v1');
 var getRepoInfo = require('git-repo-info');
 var d3 = require("d3");
 require("d3-time-format");
@@ -8,6 +9,7 @@ var parseTime = d3.timeParse("%Y-%m-%dT%H:%M:%S.%LZ");
 var formatTime = d3.timeFormat("%B %e, %Y");
 
 module.exports = (ast) => {
+    ast = convertV2ToV1(ast);
     var url = remoteOriginUrl.sync();
     var info = getRepoInfo();
     let elements = [];
@@ -46,5 +48,5 @@ module.exports = (ast) => {
     let ASTwithRevision = AST.modifyNodesByName(ast, 'Revision', (node) => {
         return revisionDiv;
     });
-    return ASTwithRevision;
+    return convertV1ToV2(ASTwithRevision);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,17 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "ajv": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -832,6 +843,16 @@
         "is-extendable": "^0.1.0"
       }
     },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
     "fs-exists-sync": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
@@ -882,9 +903,12 @@
       }
     },
     "idyll-ast": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/idyll-ast/-/idyll-ast-1.5.1.tgz",
-      "integrity": "sha1-fIWUjH/8Pxn3Hg9RrUbRJkE7HNY="
+      "version": "2.0.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/idyll-ast/-/idyll-ast-2.0.1-alpha.0.tgz",
+      "integrity": "sha512-SPBO5HXZvVieKIKZy5mamHhTfaZcmvZPKItJPwL7CjrDCfZi17WBjbhvdIScl0F3s3aYPP5vIDoP5uH4Vtn5XA==",
+      "requires": {
+        "ajv": "^6.5.2"
+      }
     },
     "ini": {
       "version": "1.3.5",
@@ -913,6 +937,11 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
       "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "lodash": {
       "version": "4.17.10",
@@ -952,6 +981,11 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
       "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "regenerate": {
       "version": "1.4.0",
@@ -1036,6 +1070,14 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
     },
     "xmlhttprequest": {
       "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "d3": "^4.0.0",
     "d3-time-format": "^2.1.1",
     "git-repo-info": "^2.0.0",
-    "idyll-ast": "^1.5.1",
+    "idyll-ast": "^2.0.1-alpha.0",
     "remote-origin-url": "^1.0.0"
   }
 }


### PR DESCRIPTION
Hi @ChristianFrisson,

We've revamped the AST structure that Idyll deals with internally to make things easier to work with and more future-proof, but need to upgrade the plugins as a result. This is going to be a major version bump to Idyll, so I'd recommend making a major version bump to this package to make it clear to users which plugin versions are compatible with which plugin versions.

The new AST format is much cleaner, and easier to operate on directly, but we offer a very similar API. For the sake of safety, rather than actually modify your AST manipulation code, I've just added code to the beginning and end to transform between the new/old AST structures and left all the original logic in place. 

Let me know if you have any questions. More documentation on the new AST [here](https://github.com/idyll-lang/idyll/blob/master/packages/idyll-ast/README.md).